### PR TITLE
Update package installation checkbox properly (-ish)

### DIFF
--- a/Alcatraz/Views/ATZRadialProgressControl.m
+++ b/Alcatraz/Views/ATZRadialProgressControl.m
@@ -40,7 +40,11 @@ const CGFloat ATZRadialProgressControl_FakeRemoveProgress = 0.66;
     bounds.size = CGSizeMake(minDimension, minDimension);
     NSTableCellView *tableCell = (NSTableCellView *)self.superview;
     ATZPackage *package = [tableCell objectValue];
-    if (self.progress == 0.f && package.isInstalled) _progress = 1.f;
+    if (self.progress == 0.f && package.isInstalled) {
+        _progress = 1.f;
+    } else if (self.progress == 1.f && !package.isInstalled) {
+        _progress = 0.f;
+    }
     NSImage *image = [NSImage imageForProgressIndicatorWithCompletionPercentage:self.progress
                                                                         package:package
                                                                            size:bounds.size


### PR DESCRIPTION
I'm sorry if this is one of those issues we are not supposed to report yet, but anyway :)

I noticed that installation checkboxes are not updated properly as you scroll through the package list. Once `progress` has been set to 1.0 for some installed package, there's basically no way back to 0.0, and the cell eventually ends up being shown for a package which is not installed.

Unfortunately, I have no experience in OS X development, but this seems to fix the problem. Actually, it feels like a wrong place for this code, shouldn't this be handled somehow via existing binding?