### PR TITLE
Refactor VC. Autoupdate packages on Xcode startup.

### DIFF
--- a/Alcatraz.xcodeproj/project.pbxproj
+++ b/Alcatraz.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		8A6EA57E1726D55300DAFE47 /* ATZProgressIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6EA57D1726D55300DAFE47 /* ATZProgressIndicator.m */; };
 		8A96E0C81729DC1200350F67 /* ATZDetailItemButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A96E0C71729DC1200350F67 /* ATZDetailItemButton.m */; };
 		8AD5249F174102F9008B451F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8AD524A2174102F9008B451F /* Localizable.strings */; };
+		CC2F438F19B937AA000C7AF9 /* ATZPackageUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CC2F438E19B937AA000C7AF9 /* ATZPackageUtils.m */; };
 		CC2F439219B93801000C7AF9 /* ATZConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = CC2F439119B93801000C7AF9 /* ATZConstants.m */; };
 		CC2F439519B9396A000C7AF9 /* ATZUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CC2F439419B9396A000C7AF9 /* ATZUtils.m */; };
 /* End PBXBuildFile section */
@@ -140,6 +141,8 @@
 		8A96E0C61729DC1200350F67 /* ATZDetailItemButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ATZDetailItemButton.h; path = Views/ATZDetailItemButton.h; sourceTree = "<group>"; };
 		8A96E0C71729DC1200350F67 /* ATZDetailItemButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ATZDetailItemButton.m; path = Views/ATZDetailItemButton.m; sourceTree = "<group>"; };
 		8AD524A1174102F9008B451F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		CC2F438D19B937AA000C7AF9 /* ATZPackageUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZPackageUtils.h; sourceTree = "<group>"; };
+		CC2F438E19B937AA000C7AF9 /* ATZPackageUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZPackageUtils.m; sourceTree = "<group>"; };
 		CC2F439019B93801000C7AF9 /* ATZConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZConstants.h; sourceTree = "<group>"; };
 		CC2F439119B93801000C7AF9 /* ATZConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZConstants.m; sourceTree = "<group>"; };
 		CC2F439319B9396A000C7AF9 /* ATZUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZUtils.h; sourceTree = "<group>"; };
@@ -296,6 +299,8 @@
 				8917DA131726B63B00F0B2D2 /* ATZDownloader.m */,
 				8917DA141726B63B00F0B2D2 /* ATZGit.h */,
 				8917DA151726B63B00F0B2D2 /* ATZGit.m */,
+				CC2F438D19B937AA000C7AF9 /* ATZPackageUtils.h */,
+				CC2F438E19B937AA000C7AF9 /* ATZPackageUtils.m */,
 				8917DA161726B63B00F0B2D2 /* ATZShell.h */,
 				8917DA171726B63B00F0B2D2 /* ATZShell.m */,
 				89B4F2BC172FF5AC001FD2E3 /* ATZPBXProjParser.h */,
@@ -439,6 +444,7 @@
 				8917D9F51726B4EE00F0B2D2 /* ATZPackage.m in Sources */,
 				8917D9F61726B4EE00F0B2D2 /* ATZPlugin.m in Sources */,
 				8917D9F71726B4EE00F0B2D2 /* ATZProjectTemplate.m in Sources */,
+				CC2F438F19B937AA000C7AF9 /* ATZPackageUtils.m in Sources */,
 				8917D9F81726B4EE00F0B2D2 /* ATZTemplate.m in Sources */,
 				8917DA051726B53000F0B2D2 /* ATZColorSchemeInstaller.m in Sources */,
 				8917DA061726B53000F0B2D2 /* ATZFileTemplateInstaller.m in Sources */,

--- a/Alcatraz.xcodeproj/project.pbxproj
+++ b/Alcatraz.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		8A6EA57E1726D55300DAFE47 /* ATZProgressIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6EA57D1726D55300DAFE47 /* ATZProgressIndicator.m */; };
 		8A96E0C81729DC1200350F67 /* ATZDetailItemButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A96E0C71729DC1200350F67 /* ATZDetailItemButton.m */; };
 		8AD5249F174102F9008B451F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8AD524A2174102F9008B451F /* Localizable.strings */; };
+		CC2F439219B93801000C7AF9 /* ATZConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = CC2F439119B93801000C7AF9 /* ATZConstants.m */; };
+		CC2F439519B9396A000C7AF9 /* ATZUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CC2F439419B9396A000C7AF9 /* ATZUtils.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -138,6 +140,10 @@
 		8A96E0C61729DC1200350F67 /* ATZDetailItemButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ATZDetailItemButton.h; path = Views/ATZDetailItemButton.h; sourceTree = "<group>"; };
 		8A96E0C71729DC1200350F67 /* ATZDetailItemButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ATZDetailItemButton.m; path = Views/ATZDetailItemButton.m; sourceTree = "<group>"; };
 		8AD524A1174102F9008B451F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		CC2F439019B93801000C7AF9 /* ATZConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZConstants.h; sourceTree = "<group>"; };
+		CC2F439119B93801000C7AF9 /* ATZConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZConstants.m; sourceTree = "<group>"; };
+		CC2F439319B9396A000C7AF9 /* ATZUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZUtils.h; sourceTree = "<group>"; };
+		CC2F439419B9396A000C7AF9 /* ATZUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZUtils.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -284,6 +290,8 @@
 		8917DA111726B63B00F0B2D2 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				CC2F439019B93801000C7AF9 /* ATZConstants.h */,
+				CC2F439119B93801000C7AF9 /* ATZConstants.m */,
 				8917DA121726B63B00F0B2D2 /* ATZDownloader.h */,
 				8917DA131726B63B00F0B2D2 /* ATZDownloader.m */,
 				8917DA141726B63B00F0B2D2 /* ATZGit.h */,
@@ -292,6 +300,8 @@
 				8917DA171726B63B00F0B2D2 /* ATZShell.m */,
 				89B4F2BC172FF5AC001FD2E3 /* ATZPBXProjParser.h */,
 				89B4F2BD172FF5AC001FD2E3 /* ATZPBXProjParser.m */,
+				CC2F439319B9396A000C7AF9 /* ATZUtils.h */,
+				CC2F439419B9396A000C7AF9 /* ATZUtils.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -441,7 +451,9 @@
 				8917DA101726B5BA00F0B2D2 /* ATZPackageFactory.m in Sources */,
 				8917DA181726B63B00F0B2D2 /* ATZDownloader.m in Sources */,
 				8917DA191726B63B00F0B2D2 /* ATZGit.m in Sources */,
+				CC2F439219B93801000C7AF9 /* ATZConstants.m in Sources */,
 				0C7AF649186B4A440064EE7B /* ATZRadialProgressControl.m in Sources */,
+				CC2F439519B9396A000C7AF9 /* ATZUtils.m in Sources */,
 				8917DA1A1726B63B00F0B2D2 /* ATZShell.m in Sources */,
 				8A6EA57E1726D55300DAFE47 /* ATZProgressIndicator.m in Sources */,
 				8A96E0C81729DC1200350F67 /* ATZDetailItemButton.m in Sources */,

--- a/Alcatraz/Alcatraz.h
+++ b/Alcatraz/Alcatraz.h
@@ -30,4 +30,6 @@
 
 + (Alcatraz *)sharedPlugin;
 
+- (void)checkForCMDLineToolsAndOpenWindow;
+
 @end

--- a/Alcatraz/Alcatraz.m
+++ b/Alcatraz/Alcatraz.m
@@ -22,11 +22,15 @@
 
 
 #import "Alcatraz.h"
-#import "ATZPluginWindowController.h"
+
 #import "ATZAlcatrazPackage.h"
 #import "ATZGit.h"
+#import "ATZPackageUtils.h"
+#import "ATZPluginWindowController.h"
 
 static Alcatraz *sharedPlugin;
+
+static NSTimeInterval const kATZOneHour = 60*60;
 
 @implementation Alcatraz
 
@@ -50,6 +54,9 @@ static Alcatraz *sharedPlugin;
         self.bundle = plugin;
         [self createMenuItem];
         [self updateAlcatraz];
+        [ATZPackageUtils reloadPackages];
+        [NSTimer scheduledTimerWithTimeInterval:kATZOneHour target:[ATZPackageUtils class] selector:@selector(reloadPackages) userInfo:nil repeats:YES];
+
     }
     return self;
 }
@@ -84,7 +91,6 @@ static Alcatraz *sharedPlugin;
         self.windowController = [[ATZPluginWindowController alloc] initWithBundle:self.bundle];
 
     [[self.windowController window] makeKeyAndOrderFront:self];
-    [self.windowController reloadPackages];
 }
 
 - (BOOL)hasNSURLSessionAvailable {

--- a/Alcatraz/Controllers/ATZPluginWindowController.h
+++ b/Alcatraz/Controllers/ATZPluginWindowController.h
@@ -22,24 +22,8 @@
 
 #import <AppKit/AppKit.h>
 
-@interface ATZPluginWindowController : NSWindowController<NSTableViewDelegate, NSControlTextEditingDelegate, NSUserNotificationCenterDelegate>
-
-@property (nonatomic, retain) NSArray *packages;
-@property (nonatomic, retain) NSPredicate *filterPredicate;
-
-@property (assign) IBOutlet NSPanel *previewPanel;
-@property (assign) IBOutlet NSImageView *previewImageView;
-@property (assign) IBOutlet NSSearchField *searchField;
-@property (assign) IBOutlet NSTableView *tableView;
+@interface ATZPluginWindowController : NSWindowController
 
 - (id)initWithBundle:(NSBundle *)bundle;
-
-- (IBAction)checkboxPressed:(NSButton *)sender;
-- (IBAction)openPackageWebsitePressed:(NSButton *)sender;
-- (IBAction)displayScreenshotPressed:(NSButton *)sender;
-
-- (IBAction)segmentedControlPressed:(id)sender;
-
-- (void)reloadPackages;
 
 @end

--- a/Alcatraz/Helpers/ATZConstants.h
+++ b/Alcatraz/Helpers/ATZConstants.h
@@ -1,0 +1,16 @@
+// urls
+extern NSString *const kATZPluginsRepoPath;
+
+// paths
+extern NSString *const kATZPluginsInstallDirectory;
+extern NSString *const kATZPluginsDataDirectory;
+
+// user notifications
+extern NSString *const kATZListOfPackagesWasUpdatedNotification;
+extern NSString *const kATZPackageWasInstalledNotification;
+extern NSString *const kATZPackageWasUpdatedNotification;
+
+// other constants
+extern NSString *const kATZXcodeProjExtension;
+extern NSString *const KATZProjectPbxprojFileName;
+

--- a/Alcatraz/Helpers/ATZConstants.m
+++ b/Alcatraz/Helpers/ATZConstants.m
@@ -1,0 +1,13 @@
+#import "ATZConstants.h"
+
+NSString *const kATZPluginsRepoPath = @"https://raw.github.com/supermarin/alcatraz-packages/master/packages.json";
+
+NSString *const kATZPluginsInstallDirectory = @"Library/Application Support/Developer/Shared/Xcode/Plug-ins";
+NSString *const kATZPluginsDataDirectory = @"Library/Application Support/Alcatraz";
+
+NSString *const kATZListOfPackagesWasUpdatedNotification = @"ATZListOfPackagesWasUpdatedNotification";
+NSString *const kATZPackageWasInstalledNotification = @"ATZPackageWasInstalledNotification";
+NSString *const kATZPackageWasUpdatedNotification = @"ATZPackageWasUpdatedNotification";
+
+NSString *const kATZXcodeProjExtension = @"xcodeproj";
+NSString *const KATZProjectPbxprojFileName = @"project.pbxproj";

--- a/Alcatraz/Helpers/ATZDownloader.m
+++ b/Alcatraz/Helpers/ATZDownloader.m
@@ -23,7 +23,8 @@
 
 #import "ATZDownloader.h"
 
-static NSString *const PLUGINS_REPO_PATH = @"https://raw.github.com/supermarin/alcatraz-packages/master/packages.json";
+#import "ATZConstants.h"
+
 static NSString *const PROGRESS = @"progress";
 static NSString *const COMPLETION = @"completion";
 
@@ -45,7 +46,7 @@ static NSString *const COMPLETION = @"completion";
 }
 
 - (void)downloadPackageListWithCompletion:(ATZJSONDownloadCompletion)completion {
-    [self downloadFileFromPath:PLUGINS_REPO_PATH
+    [self downloadFileFromPath:kATZPluginsRepoPath
                       progress:^(CGFloat progress) {}
                     completion:^(NSData *data, NSError *error) {
                         
@@ -118,9 +119,5 @@ didCompleteWithError:(NSError *)error {
                                            delegateQueue:[NSOperationQueue mainQueue]];
     return _urlSession;
 }
-
-
-
-
 
 @end

--- a/Alcatraz/Helpers/ATZPackageUtils.h
+++ b/Alcatraz/Helpers/ATZPackageUtils.h
@@ -1,0 +1,23 @@
+#import <Foundation/Foundation.h>
+
+@class ATZPackage;
+
+@interface ATZPackageUtils : NSObject
+
+/*
+ * Getters
+ */
++ (NSArray *)allPackages;
+
+/*
+ * Reloaders
+ */
++ (void)reloadPackages;
+
+/*
+ * User Notification Methods
+ */
++ (void)postUserNotificationForInstalledPackage:(ATZPackage *)package;
++ (void)postUserNotificationForUpdatedPackage:(ATZPackage *)package;
+
+@end

--- a/Alcatraz/Helpers/ATZPackageUtils.m
+++ b/Alcatraz/Helpers/ATZPackageUtils.m
@@ -1,0 +1,135 @@
+#import "ATZPackageUtils.h"
+
+#import "Alcatraz.h"
+#import "ATZConstants.h"
+#import "ATZDownloader.h"
+#import "ATZPackage.h"
+#import "ATZPackageFactory.h"
+#import "ATZPBXProjParser.h"
+#import "ATZUtils.h"
+
+static NSArray *__allPackages;
+
+@interface ATZPackageUtils () <NSUserNotificationCenterDelegate>
+@end
+
+@implementation ATZPackageUtils
+
+#pragma mark -
+#pragma mark Private Methods
+
++ (ATZPackageUtils *)shared
+{
+  static ATZPackageUtils *shared;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    shared = [[ATZPackageUtils alloc] init];
+  });
+  return shared;
+}
+
+#pragma mark -
+#pragma mark Public Getters
+
++ (NSArray *)allPackages
+{
+  return __allPackages;
+}
+
+#pragma mark -
+#pragma mark Public Methods
+
++ (void)reloadPackages
+{
+  ATZDownloader *downloader = [ATZDownloader new];
+  [downloader downloadPackageListWithCompletion:^(NSDictionary *packageList, NSError *error) {
+    if (error) {
+      NSLog(@"[Alcatraz][ATZPackageUtils] Error while downloading packages! %@", error);
+    } else {
+      __allPackages = [ATZPackageFactory createPackagesFromDicts:packageList];
+      [[NSNotificationCenter defaultCenter] postNotificationName:kATZListOfPackagesWasUpdatedNotification object:nil];
+
+      [self updatePackages:__allPackages];
+    }
+  }];
+}
+
+#pragma mark -
+#pragma mark Methods to update packages
+
++ (void)updatePackages:(NSArray *)packages
+{
+  for (ATZPackage *package in packages) {
+    if ([package isInstalled]) {
+      [self enqueuePackageUpdate:package];
+    }
+  }
+}
+
++ (void)enqueuePackageUpdate:(ATZPackage *)package
+{
+  if (!package.isInstalled) {
+    return;
+  }
+
+  NSOperation *updateOperation = [NSBlockOperation blockOperationWithBlock:^{
+    [package updateWithProgress:^(NSString *progressMessage, CGFloat progress){}
+                     completion:^(NSError *failure) {
+      if (failure) {
+        NSLog(@"[Alcatraz][ATZPackageUtils] Error while updating package %@! %@", package.name, failure);
+        return;
+      }
+
+      [[NSNotificationCenter defaultCenter] postNotificationName:kATZPackageWasUpdatedNotification object:package];
+      [self postUserNotificationForUpdatedPackage:package];
+    }];
+  }];
+  if ([[NSOperationQueue mainQueue] operations].lastObject) {
+    [updateOperation addDependency:[[NSOperationQueue mainQueue] operations].lastObject];
+  }
+  [[NSOperationQueue mainQueue] addOperation:updateOperation];
+}
+
+#pragma mark -
+#pragma mark User Notification Methods
+
++ (void)_becomeUserNotificationCenterDelegate
+{
+  [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:[self shared]];
+}
+
++ (void)postUserNotificationForInstalledPackage:(ATZPackage *)package
+{
+  [self _becomeUserNotificationCenterDelegate];
+
+  NSUserNotification *notification = [NSUserNotification new];
+  notification.title = [NSString stringWithFormat:@"%@ installed", package.type];
+  NSString *restartText = package.requiresRestart ? @" Please restart Xcode to use it." : @"";
+  notification.informativeText = [NSString stringWithFormat:@"%@ was installed successfully!\n%@", package.name, restartText];
+
+  [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+}
+
++ (void)postUserNotificationForUpdatedPackage:(ATZPackage *)package
+{
+  [self _becomeUserNotificationCenterDelegate];
+
+  NSUserNotification *notification = [NSUserNotification new];
+  notification.title = [NSString stringWithFormat:@"%@ updated", package.type];
+  NSString *restartText = package.requiresRestart ? @"Please restart Xcode to use it." : @"";
+  notification.informativeText = [NSString stringWithFormat:@"%@ was successfully updated!\n%@", package.name, restartText];
+
+  [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+}
+
+- (void)userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:(NSUserNotification *)notification
+{
+  [[Alcatraz sharedPlugin] checkForCMDLineToolsAndOpenWindow];
+}
+
+- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center shouldPresentNotification:(NSUserNotification *)notification
+{
+  return YES;
+}
+
+@end

--- a/Alcatraz/Helpers/ATZUtils.h
+++ b/Alcatraz/Helpers/ATZUtils.h
@@ -1,0 +1,3 @@
+NSString *ATZPluginsDataDirectoryPath();
+
+NSString *ATZPluginsInstallPath();

--- a/Alcatraz/Helpers/ATZUtils.m
+++ b/Alcatraz/Helpers/ATZUtils.m
@@ -1,0 +1,13 @@
+#import "ATZUtils.h"
+
+#import "ATZConstants.h"
+
+NSString *ATZPluginsDataDirectoryPath()
+{
+  return [NSHomeDirectory() stringByAppendingPathComponent:kATZPluginsDataDirectory];
+}
+
+NSString *ATZPluginsInstallPath()
+{
+  return [NSHomeDirectory() stringByAppendingPathComponent:kATZPluginsInstallDirectory];
+}

--- a/Alcatraz/Installers/ATZInstaller.m
+++ b/Alcatraz/Installers/ATZInstaller.m
@@ -22,8 +22,8 @@
 
 #import "ATZInstaller.h"
 #import "ATZPackage.h"
+#import "ATZUtils.h"
 
-static NSString *const ALCATRAZ_DATA_DIR = @"Library/Application Support/Alcatraz";
 const CGFloat ATZFakeDownloadProgress = 0.33;
 const CGFloat ATZFakeInstallProgress = 0.66;
 
@@ -94,7 +94,7 @@ const CGFloat ATZFakeInstallProgress = 0.66;
 #pragma mark - Abstract
 
 - (NSString *)alcatrazDownloadsPath {
-    return [NSHomeDirectory() stringByAppendingPathComponent:ALCATRAZ_DATA_DIR];
+    return ATZPluginsDataDirectoryPath();
 }
 
 

--- a/Alcatraz/Installers/ATZPluginInstaller.m
+++ b/Alcatraz/Installers/ATZPluginInstaller.m
@@ -26,14 +26,13 @@
 #import "ATZShell.h"
 #import "ATZGit.h"
 #import "ATZPBXProjParser.h"
+#import "ATZConstants.h"
+#import "ATZUtils.h"
 
-static NSString *const INSTALLED_PLUGINS_RELATIVE_PATH = @"Library/Application Support/Developer/Shared/Xcode/Plug-ins";
 static NSString *const DOWNLOADED_PLUGINS_RELATIVE_PATH = @"Plug-ins";
 
 static NSString *const XCODE_BUILD = @"/usr/bin/xcodebuild";
 static NSString *const PROJECT = @"-project";
-static NSString *const XCODEPROJ = @".xcodeproj";
-static NSString *const PROJECT_PBXPROJ = @"project.pbxproj";
 
 @implementation ATZPluginInstaller
 
@@ -62,11 +61,10 @@ static NSString *const PROJECT_PBXPROJ = @"project.pbxproj";
 
 // This is a temporary support for installs in /tmp.
 - (NSString *)pathForInstalledPackage:(ATZPackage *)package {
-    NSString *pluginsInstallPath = [NSHomeDirectory() stringByAppendingPathComponent:INSTALLED_PLUGINS_RELATIVE_PATH];
     NSString *pluginInstallName = [self installNameFromPbxproj:package] ?: package.name;
 
-    return [[pluginsInstallPath stringByAppendingPathComponent:pluginInstallName]
-                                       stringByAppendingString:package.extension];
+    return [[ATZPluginsInstallPath() stringByAppendingPathComponent:pluginInstallName]
+                                            stringByAppendingString:package.extension];
 }
 
 
@@ -117,7 +115,7 @@ static NSString *const PROJECT_PBXPROJ = @"project.pbxproj";
 
 - (NSString *)findXcodeprojPathForPlugin:(ATZPlugin *)plugin {
     NSString *clonedDirectory = [self pathForDownloadedPackage:plugin];
-    NSString *xcodeProjFilename = [plugin.name stringByAppendingString:XCODEPROJ];
+    NSString *xcodeProjFilename = [plugin.name stringByAppendingPathExtension:kATZXcodeProjExtension];
 
     NSDirectoryEnumerator *enumerator = [[NSFileManager sharedManager] enumeratorAtPath:clonedDirectory];
     NSString *directoryEntry;
@@ -132,8 +130,8 @@ static NSString *const PROJECT_PBXPROJ = @"project.pbxproj";
 
 - (NSString *)installNameFromPbxproj:(ATZPackage *)package {
     NSString *pbxprojPath = [[[[self pathForDownloadedPackage:package]
-                               stringByAppendingPathComponent:package.name] stringByAppendingString:XCODEPROJ]
-                             stringByAppendingPathComponent:PROJECT_PBXPROJ];
+                               stringByAppendingPathComponent:package.name] stringByAppendingPathExtension:kATZXcodeProjExtension]
+                             stringByAppendingPathComponent:KATZProjectPbxprojFileName];
 
     return [ATZPbxprojParser xcpluginNameFromPbxproj:pbxprojPath];
 }

--- a/Alcatraz/Packages/ATZAlcatrazPackage.m
+++ b/Alcatraz/Packages/ATZAlcatrazPackage.m
@@ -38,7 +38,7 @@
         @"branch": @"deploy"
     }];
     
-    [alcatraz updateWithProgress:^(NSString *proggressMessage, CGFloat progress){} completion:^(NSError *failure) {
+    [alcatraz updateWithProgress:^(NSString *progressMessage, CGFloat progress){} completion:^(NSError *failure) {
         if (failure)
             NSLog(@"Alcatraz update failed! %@", failure);
     }];

--- a/Alcatraz/Packages/ATZPackage.h
+++ b/Alcatraz/Packages/ATZPackage.h
@@ -41,10 +41,10 @@
 
 - (id)initWithDictionary:(NSDictionary *)dict;
 
-- (void)installWithProgress:(void(^)(NSString *proggressMessage, CGFloat progress))progress
+- (void)installWithProgress:(void(^)(NSString *progressMessage, CGFloat progress))progress
                  completion:(void(^)(NSError *failure))completion;
 
-- (void)updateWithProgress:(void(^)(NSString *proggressMessage, CGFloat progress))progress
+- (void)updateWithProgress:(void(^)(NSString *progressMessage, CGFloat progress))progress
                 completion:(void(^)(NSError *failure))completion;
 
 - (void)removeWithCompletion:(void(^)(NSError *failure))completion;

--- a/TestProject/TestProject.xcodeproj/project.pbxproj
+++ b/TestProject/TestProject.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		89BBB2C118C3EAA200546623 /* ATZSegmentedCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 89BBB29918C3EAA200546623 /* ATZSegmentedCell.m */; };
 		89BBB2C318C3EAA200546623 /* ATZVersionLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 89BBB29D18C3EAA200546623 /* ATZVersionLabel.m */; };
 		89BBB2C618C3EB0C00546623 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89BBB2C418C3EAFD00546623 /* QuartzCore.framework */; };
+		CC22B0BC19C13CEB00640934 /* ATZConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = CC22B0B919C13CEB00640934 /* ATZConstants.m */; };
+		CC22B0BD19C13CEB00640934 /* ATZUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CC22B0BB19C13CEB00640934 /* ATZUtils.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -170,6 +172,10 @@
 		89BBB29C18C3EAA200546623 /* ATZVersionLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZVersionLabel.h; sourceTree = "<group>"; };
 		89BBB29D18C3EAA200546623 /* ATZVersionLabel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZVersionLabel.m; sourceTree = "<group>"; };
 		89BBB2C418C3EAFD00546623 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		CC22B0B819C13CEB00640934 /* ATZConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZConstants.h; sourceTree = "<group>"; };
+		CC22B0B919C13CEB00640934 /* ATZConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZConstants.m; sourceTree = "<group>"; };
+		CC22B0BA19C13CEB00640934 /* ATZUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZUtils.h; sourceTree = "<group>"; };
+		CC22B0BB19C13CEB00640934 /* ATZUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZUtils.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -353,6 +359,8 @@
 		89BBB26518C3EAA200546623 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				CC22B0B819C13CEB00640934 /* ATZConstants.h */,
+				CC22B0B919C13CEB00640934 /* ATZConstants.m */,
 				89BBB26618C3EAA200546623 /* ATZDownloader.h */,
 				89BBB26718C3EAA200546623 /* ATZDownloader.m */,
 				89BBB26818C3EAA200546623 /* ATZGit.h */,
@@ -361,6 +369,8 @@
 				89BBB26B18C3EAA200546623 /* ATZPBXProjParser.m */,
 				89BBB26C18C3EAA200546623 /* ATZShell.h */,
 				89BBB26D18C3EAA200546623 /* ATZShell.m */,
+				CC22B0BA19C13CEB00640934 /* ATZUtils.h */,
+				CC22B0BB19C13CEB00640934 /* ATZUtils.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -589,7 +599,9 @@
 				89BBB2AD18C3EAA200546623 /* ATZFileTemplateInstaller.m in Sources */,
 				89BBB21B18C3E99E00546623 /* main.m in Sources */,
 				89BBB2B518C3EAA200546623 /* ATZColorScheme.m in Sources */,
+				CC22B0BC19C13CEB00640934 /* ATZConstants.m in Sources */,
 				89BBB2BA18C3EAA200546623 /* ATZProjectTemplate.m in Sources */,
+				CC22B0BD19C13CEB00640934 /* ATZUtils.m in Sources */,
 				89BBB2BE18C3EAA200546623 /* ATZPackageTableCellView.m in Sources */,
 				89BBB2BD18C3EAA200546623 /* ATZDetailItemButton.m in Sources */,
 				89BBB2B718C3EAA200546623 /* ATZPackage.m in Sources */,

--- a/TestProject/TestProject.xcodeproj/project.pbxproj
+++ b/TestProject/TestProject.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		89BBB2C618C3EB0C00546623 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89BBB2C418C3EAFD00546623 /* QuartzCore.framework */; };
 		CC22B0BC19C13CEB00640934 /* ATZConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = CC22B0B919C13CEB00640934 /* ATZConstants.m */; };
 		CC22B0BD19C13CEB00640934 /* ATZUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CC22B0BB19C13CEB00640934 /* ATZUtils.m */; };
+		CC22B0C019C13D2D00640934 /* ATZPackageUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CC22B0BF19C13D2D00640934 /* ATZPackageUtils.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -176,6 +177,8 @@
 		CC22B0B919C13CEB00640934 /* ATZConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZConstants.m; sourceTree = "<group>"; };
 		CC22B0BA19C13CEB00640934 /* ATZUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZUtils.h; sourceTree = "<group>"; };
 		CC22B0BB19C13CEB00640934 /* ATZUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZUtils.m; sourceTree = "<group>"; };
+		CC22B0BE19C13D2D00640934 /* ATZPackageUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZPackageUtils.h; sourceTree = "<group>"; };
+		CC22B0BF19C13D2D00640934 /* ATZPackageUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZPackageUtils.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -365,6 +368,8 @@
 				89BBB26718C3EAA200546623 /* ATZDownloader.m */,
 				89BBB26818C3EAA200546623 /* ATZGit.h */,
 				89BBB26918C3EAA200546623 /* ATZGit.m */,
+				CC22B0BE19C13D2D00640934 /* ATZPackageUtils.h */,
+				CC22B0BF19C13D2D00640934 /* ATZPackageUtils.m */,
 				89BBB26A18C3EAA200546623 /* ATZPBXProjParser.h */,
 				89BBB26B18C3EAA200546623 /* ATZPBXProjParser.m */,
 				89BBB26C18C3EAA200546623 /* ATZShell.h */,
@@ -598,6 +603,7 @@
 				89BBB2C018C3EAA200546623 /* ATZRadialProgressControl.m in Sources */,
 				89BBB2AD18C3EAA200546623 /* ATZFileTemplateInstaller.m in Sources */,
 				89BBB21B18C3E99E00546623 /* main.m in Sources */,
+				CC22B0C019C13D2D00640934 /* ATZPackageUtils.m in Sources */,
 				89BBB2B518C3EAA200546623 /* ATZColorScheme.m in Sources */,
 				CC22B0BC19C13CEB00640934 /* ATZConstants.m in Sources */,
 				89BBB2BA18C3EAA200546623 /* ATZProjectTemplate.m in Sources */,


### PR DESCRIPTION
This PR consists of 2 commits.
- In first one I moved all common constants to ATZConstants and ATZUtils. Also I fixed usages of `stringByAppending*` when composing paths using path extension.
- In second commit I moved all business logic from view controller to `ATZPackageUtils` which gave ability to update packages on Xcode startup rather then when Alcatraz window is opened. Also timer will be scheduled to requests updates every hour. And all UI/IBOutlets stuff was moved under category in implementation file to clear VC header file.

Tested in Xcode 6 GM.

P.S. This is not random PR. Other PRs based on this one, which will extend Alcatraz functionality, will be sent.