### PR TITLE
Small fix to the search field predicate to include 'summary' field

### DIFF
--- a/Alcatraz/Controllers/ATZPluginWindowController.m
+++ b/Alcatraz/Controllers/ATZPluginWindowController.m
@@ -39,7 +39,7 @@
 
 static NSString *const ALL_ITEMS_ID = @"AllItemsToolbarItem";
 static NSString *const CLASS_PREDICATE_FORMAT = @"(self isKindOfClass: %@)";
-static NSString *const SEARCH_PREDICATE_FORMAT = @"(name contains[cd] %@ OR description contains[cd] %@)";
+static NSString *const SEARCH_PREDICATE_FORMAT = @"(name contains[cd] %@ OR summary contains[cd] %@)";
 static NSString *const INSTALLED_PREDICATE_FORMAT = @"(installed == YES)";
 
 typedef NS_ENUM(NSInteger, ATZFilterSegment) {


### PR DESCRIPTION
The search field predicated appeared to match based on the name of the plugins (ATZPackage) objects but was not matching on the Summary attribute. Instead it was matching on "description" which seemed to return no further results.