### PR TITLE
Fixes two typos in the install script

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -6,5 +6,5 @@ PLUGINS_DIR="${HOME}/Library/Application Support/Developer/Shared/Xcode/Plug-ins
 mkdir -p "${PLUGINS_DIR}"
 curl -L $DOWNLOAD_URI | tar xvz -C "${PLUGINS_DIR}"
 
-echo "Alcatraz successfuly installed!!1!🍻   Please restart your Xcode."
+echo "Alcatraz successfully installed!!!!🍻   Please restart your Xcode."
 


### PR DESCRIPTION
I'm not sure if these *typos* in the install script are intentional, but I figured I'd submit a quick PR just in case you wanted to clean them up.