### PR TITLE
clean the build directory when executing xcodebuild for issue #250

### DIFF
--- a/Alcatraz/Installers/ATZPluginInstaller.m
+++ b/Alcatraz/Installers/ATZPluginInstaller.m
@@ -109,7 +109,7 @@ static NSString *const PROJECT_PBXPROJ = @"project.pbxproj";
     }
 
     ATZShell *shell = [ATZShell new];
-    [shell executeCommand:XCODE_BUILD withArguments:@[PROJECT, xcodeProjPath] completion:^(NSString *output, NSError *error) {
+    [shell executeCommand:XCODE_BUILD withArguments:@[@"clean", @"build", PROJECT, xcodeProjPath] completion:^(NSString *output, NSError *error) {
         NSLog(@"Xcodebuild output: %@", output);
         completion(error);
     }];


### PR DESCRIPTION
Added `clean` argument to `xcodebuild` to clean the build products before building the plugin.

This fix resolves the issue with my plugin [BBUncrustifyPlugin](https://github.com/benoitsan/BBUncrustifyPlugin-Xcode). I tested it and now the xib file is correctly copied.