### PR TITLE
Xcode 6.4

### DIFF
--- a/Alcatraz/Alcatraz-Info.plist
+++ b/Alcatraz/Alcatraz-Info.plist
@@ -24,6 +24,7 @@
 	<string>1</string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>

--- a/Alcatraz/Alcatraz.m
+++ b/Alcatraz/Alcatraz.m
@@ -52,7 +52,9 @@ static Alcatraz *sharedPlugin;
 - (id)initWithBundle:(NSBundle *)plugin {
     if (self = [super init]) {
         self.bundle = plugin;
-        [self createMenuItem];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self createMenuItem];
+        });
         [self updateAlcatraz];
     }
     return self;


### PR DESCRIPTION
This makes Alcatraz work again in Xcode 6.4 beta

There's an open issue, though, building with 6.4 didn't work for me, because the NIBs would actually not end up in the final bundle. Building Alcatraz with these changes using 6.3.1 would load just fine in 6.4 beta, though.  ¯\\\_(ツ)\_/¯ 

Fixes #264