### PR TITLE
Xcode 6.3.2 support

### DIFF
--- a/Alcatraz/Alcatraz-Info.plist
+++ b/Alcatraz/Alcatraz-Info.plist
@@ -34,6 +34,7 @@
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
+		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 	</array>
 	<key>XC4Compatible</key>
 	<true/>

--- a/Alcatraz/Alcatraz.m
+++ b/Alcatraz/Alcatraz.m
@@ -52,7 +52,9 @@ static Alcatraz *sharedPlugin;
 - (id)initWithBundle:(NSBundle *)plugin {
     if (self = [super init]) {
         self.bundle = plugin;
-        [self createMenuItem];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self createMenuItem];
+        });
         [self updateAlcatraz];
     }
     return self;
@@ -104,7 +106,6 @@ static Alcatraz *sharedPlugin;
 - (void)updateAlcatraz {
     NSOperationQueue *queue = [[NSOperationQueue alloc] init];
     [queue addOperationWithBlock:^{
-    
         [ATZAlcatrazPackage update];
     }];
 }


### PR DESCRIPTION
Add Xcode 6.3.2 support.
Gives a warning about "Unexpected code bundles". "Loads bundle" makes it work.
I used a fix from @neonichu allowing menu item to appear. (see #270)