### PR TITLE
Comment in install.sh contains 1 instead of !

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -6,5 +6,4 @@ PLUGINS_DIR="${HOME}/Library/Application Support/Developer/Shared/Xcode/Plug-ins
 mkdir -p "${PLUGINS_DIR}"
 curl -L $DOWNLOAD_URI | tar xvz -C "${PLUGINS_DIR}"
 
-echo "Alcatraz successfully installed!!1!🍻   Please restart your Xcode."
-
+echo "Alcatraz successfully installed!!!!🍻   Please restart your Xcode."


### PR DESCRIPTION
The comment at the end of the install script contains a 1 instead of a !. This patch would fix it.