### PR TITLE
Removed period after `rm -rf` tutorial command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Open up your terminal and paste this:
 rm -rf ~/Library/Application\ Support/Developer/Shared/Xcode/Plug-ins/Alcatraz.xcplugin
 ```
 
-To remove all packages installed via Alcatraz, run `rm -rf ~/Library/Application\ Support/Alcatraz/`.
+To remove all packages installed via Alcatraz, run `rm -rf ~/Library/Application\ Support/Alcatraz/`
 
 ## Team
 


### PR DESCRIPTION
Accidental copying and pasting may result in users `rm -rf`-ing the support files but also their current directory (if they accidentally copy the "." as well, as I almost did!)

Very minor (1 character) change, but very major repercussions :)